### PR TITLE
Add support to GeoStore for 'intersects' logic

### DIFF
--- a/browser/terraformer-geostore.js
+++ b/browser/terraformer-geostore.js
@@ -644,6 +644,139 @@ Stream.prototype.unpipe = function (destination) {
 
   };
 
+  GeoStore.prototype.intersects = function(geojson){
+    var args = Array.prototype.slice.call(arguments);
+    args.shift();
+
+    var callback = args.pop();
+    if (args.length) {
+      var indexQuery = args[0];
+    }
+
+
+    // make a new deferred
+    var shape = new Terraformer.Primitive(geojson);
+
+    // create our envelope
+    var envelope = Terraformer.Tools.calculateEnvelope(shape);
+
+    // search the index
+    this.index.search(envelope, bind(this, function(err, found){
+      var results = [];
+      var completed = 0;
+      var errors = 0;
+      var self = this;
+      var sync = new Sync();
+      var set;
+      var i;
+
+      // should we do set elimination with additional indexes?
+      if (indexQuery && self._additional_indexes.length) {
+        // convert "found" to an object with keys
+        set = { };
+
+        for (i = 0; i < found.length; i++) {
+          set[found[i]] = true;
+        }
+
+        // iterate through the queries, find the correct indexes, and apply them
+        var keys = Object.keys(indexQuery);
+
+        for (var j = 0; j < keys.length; j++) {
+          for (i = 0; i < self._additional_indexes.length; i++) {
+            // index property matches query
+            if (self._additional_indexes[i].property === keys[j]) {
+              var which = indexQuery[keys[j]], index = self._additional_indexes[i].index;
+
+              sync.next(function (index, which, set, cb) {
+                var next = this;
+                eliminateForIndex(index, which, set, function (err, newSet) {
+                  set = newSet;
+                  cb(err);
+                });
+              }, index, which, set);
+            }
+          }
+        }
+
+      }
+
+      sync.next(function () {
+        // if we have a set, it is our new "found"
+        if (set) {
+          found = Object.keys(set);
+        }
+
+        // the function to evalute results from the index
+        var evaluate = function(primitive){
+          completed++;
+          if ( primitive ){
+            var geometry = new Terraformer.Primitive(primitive.geometry);
+
+            if (shape.intersects(geometry)){
+              if (self._stream) {
+                if (completed === found.length) {
+                  self._stream.emit("data", primitive);
+                  self._stream.emit("end");
+                } else {
+                  self._stream.emit("data", primitive);
+                }
+              } else {
+                results.push(primitive);
+              }
+            }
+
+            if(completed >= found.length){
+              if(!errors){
+                if (self._stream) {
+                  self._stream = null;
+                } else if (callback) {
+                  callback( null, results );
+                }
+              } else {
+                if (callback) {
+                  callback("Could not get all geometries", null);
+                }
+              }
+            }
+          }
+        };
+
+        var error = function(){
+          completed++;
+          errors++;
+          if(completed >= found.length){
+            if (callback) {
+              callback("Could not get all geometries", null);
+            }
+          }
+        };
+
+        // for each result see if the polygon contains the point
+        if(found && found.length){
+          var getCB = function(err, result){
+            if (err) {
+              error();
+            } else {
+              evaluate( result );
+            }
+          };
+
+          for (var i = 0; i < found.length; i++) {
+            self.get(found[i], getCB);
+          }
+        } else {
+          if (callback) {
+            callback(null, results);
+          }
+        }
+      });
+
+      sync.start();
+
+    }));
+  };
+
   GeoStore.prototype.update = function(geojson, callback){
     var feature = Terraformer.Primitive(geojson);
 

--- a/browser/terraformer-geostore.js
+++ b/browser/terraformer-geostore.js
@@ -378,15 +378,28 @@ Stream.prototype.unpipe = function (destination) {
     }));
   };
 
-  GeoStore.prototype.contains = function(geojson){
-    var args = Array.prototype.slice.call(arguments);
-    args.shift();
-
-    var callback = args.pop();
-    if (args.length) {
-      var indexQuery = args[0];
+  GeoStore.prototype._genericSpatialOperation = function (geojson, indexQuery, operationName, callback) {
+    var indexSearchMethod, shapeGeometryTest;
+    switch (operationName) {
+      case 'within':
+        indexSearchMethod = this.index.within;
+        shapeGeometryTest = function(geometry, shape) {
+          return geometry.within(shape);
+        };
+        break;
+      case 'contains':
+        indexSearchMethod = this.index.search;
+        shapeGeometryTest = function(geometry, shape) {
+          return shape.within(geometry);
+        };
+        break;
+      case 'intersects':
+        indexSearchMethod = this.index.search;
+        shapeGeometryTest = function(geometry, shape) {
+          return shape.intersects(geometry);
+        };
+        break;
     }
-
 
     // make a new deferred
     var shape = new Terraformer.Primitive(geojson);
@@ -395,7 +408,7 @@ Stream.prototype.unpipe = function (destination) {
     var envelope = Terraformer.Tools.calculateEnvelope(shape);
 
     // search the index
-    this.index.search(envelope, bind(this, function(err, found){
+    indexSearchMethod(envelope, bind(this, function(err, found){
       var results = [];
       var completed = 0;
       var errors = 0;
@@ -432,7 +445,6 @@ Stream.prototype.unpipe = function (destination) {
             }
           }
         }
-
       }
 
       sync.next(function () {
@@ -446,11 +458,14 @@ Stream.prototype.unpipe = function (destination) {
           completed++;
           if ( primitive ){
             var geometry = new Terraformer.Primitive(primitive.geometry);
-
-            if (shape.within(geometry)){
+            if (shapeGeometryTest(geometry, shape)){
               if (self._stream) {
                 if (completed === found.length) {
-                  self._stream.emit("data", primitive);
+                  if (operationName == "within") {
+                    self._stream.emit("done", primitive);
+                  } else {
+                    self._stream.emit("data", primitive);
+                  }
                   self._stream.emit("end");
                 } else {
                   self._stream.emit("data", primitive);
@@ -509,272 +524,44 @@ Stream.prototype.unpipe = function (destination) {
       sync.start();
 
     }));
+  };
+
+  GeoStore.prototype.intersects = function (geojson) {
+    var indexQuery;
+    var args = Array.prototype.slice.call(arguments);
+    args.shift();
+
+    var callback = args.pop();
+    if (args.length) {
+      indexQuery = args[0];
+    }
+
+    return this._genericSpatialOperation(geojson, indexQuery, 'intersects', callback);
+  };
+
+  GeoStore.prototype.contains = function (geojson) {
+    var indexQuery;
+    var args = Array.prototype.slice.call(arguments);
+    args.shift();
+
+    var callback = args.pop();
+    if (args.length) {
+      indexQuery = args[0];
+    }
+
+    return this._genericSpatialOperation(geojson, indexQuery, 'contains', callback);
   };
 
   GeoStore.prototype.within = function(geojson){
+    var indexQuery;
     var args = Array.prototype.slice.call(arguments);
     args.shift();
-
     var callback = args.pop();
     if (args.length) {
-      var indexQuery = args[0];
+      indexQuery = args[0];
     }
 
-    // make a new deferred
-    var shape = new Terraformer.Primitive(geojson);
-
-    // create our envelope
-    var envelope = Terraformer.Tools.calculateEnvelope(shape);
-
-    // search the index using within
-    this.index.within(envelope, bind(this, function(err, found){
-      var results = [];
-      var completed = 0;
-      var errors = 0;
-      var self = this;
-      var sync = new Sync();
-      var set;
-      var i;
-
-      // should we do set elimination with additional indexes?
-      if (indexQuery && self._additional_indexes.length) {
-        // convert "found" to an object with keys
-        set = { };
-
-        for (i = 0; i < found.length; i++) {
-          set[found[i]] = true;
-        }
-
-        // iterate through the queries, find the correct indexes, and apply them
-        var keys = Object.keys(indexQuery);
-
-        for (var j = 0; j < keys.length; j++) {
-          for (i = 0; i < self._additional_indexes.length; i++) {
-            // index property matches query
-            if (self._additional_indexes[i].property === keys[j]) {
-              var which = indexQuery[keys[j]], index = self._additional_indexes[i].index;
-
-              sync.next(function (index, which, set, cb) {
-                var next = this;
-                eliminateForIndex(index, which, set, function (err, newSet) {
-                  set = newSet;
-                  cb(err);
-                });
-              }, index, which, set);
-            }
-          }
-        }
-
-      }
-
-      sync.next(function () {
-        // if we have a set, it is our new "found"
-        if (set) {
-          found = Object.keys(set);
-        }
-
-        // the function to evalute results from the index
-        var evaluate = function(primitive){
-          completed++;
-          if ( primitive ){
-            var geometry = new Terraformer.Primitive(primitive.geometry);
-
-            if (geometry.within(shape)){
-              if (self._stream) {
-                if (completed === found.length) {
-                  self._stream.emit("done", primitive);
-                  self._stream.emit("end");
-                } else {
-                  self._stream.emit("data", primitive);
-                }
-              } else {
-                results.push(primitive);
-              }
-            }
-
-            if(completed >= found.length){
-              if(!errors){
-                if (self._stream) {
-                  self._stream = null;
-                } else if (callback) {
-                  callback( null, results );
-                }
-              } else {
-                if (callback) {
-                  callback("Could not get all geometries", null);
-                }
-              }
-            }
-          }
-        };
-
-        var error = function(){
-          completed++;
-          errors++;
-          if(completed >= found.length){
-            if (callback) {
-              callback("Could not get all geometries", null);
-            }
-          }
-        };
-
-        // for each result see if the polygon contains the point
-        if(found && found.length){
-          var getCB = function(err, result){
-            if (err) {
-              error();
-            } else {
-              evaluate( result );
-            }
-          };
-
-          for (var i = 0; i < found.length; i++) {
-            self.get(found[i], getCB);
-          }
-        } else {
-          if (callback) {
-            callback(null, results);
-          }
-        }
-
-      });
-
-      sync.start();
-    }));
-
-  };
-
-  GeoStore.prototype.intersects = function(geojson){
-    var args = Array.prototype.slice.call(arguments);
-    args.shift();
-
-    var callback = args.pop();
-    if (args.length) {
-      var indexQuery = args[0];
-    }
-
-
-    // make a new deferred
-    var shape = new Terraformer.Primitive(geojson);
-
-    // create our envelope
-    var envelope = Terraformer.Tools.calculateEnvelope(shape);
-
-    // search the index
-    this.index.search(envelope, bind(this, function(err, found){
-      var results = [];
-      var completed = 0;
-      var errors = 0;
-      var self = this;
-      var sync = new Sync();
-      var set;
-      var i;
-
-      // should we do set elimination with additional indexes?
-      if (indexQuery && self._additional_indexes.length) {
-        // convert "found" to an object with keys
-        set = { };
-
-        for (i = 0; i < found.length; i++) {
-          set[found[i]] = true;
-        }
-
-        // iterate through the queries, find the correct indexes, and apply them
-        var keys = Object.keys(indexQuery);
-
-        for (var j = 0; j < keys.length; j++) {
-          for (i = 0; i < self._additional_indexes.length; i++) {
-            // index property matches query
-            if (self._additional_indexes[i].property === keys[j]) {
-              var which = indexQuery[keys[j]], index = self._additional_indexes[i].index;
-
-              sync.next(function (index, which, set, cb) {
-                var next = this;
-                eliminateForIndex(index, which, set, function (err, newSet) {
-                  set = newSet;
-                  cb(err);
-                });
-              }, index, which, set);
-            }
-          }
-        }
-
-      }
-
-      sync.next(function () {
-        // if we have a set, it is our new "found"
-        if (set) {
-          found = Object.keys(set);
-        }
-
-        // the function to evalute results from the index
-        var evaluate = function(primitive){
-          completed++;
-          if ( primitive ){
-            var geometry = new Terraformer.Primitive(primitive.geometry);
-
-            if (shape.intersects(geometry)){
-              if (self._stream) {
-                if (completed === found.length) {
-                  self._stream.emit("data", primitive);
-                  self._stream.emit("end");
-                } else {
-                  self._stream.emit("data", primitive);
-                }
-              } else {
-                results.push(primitive);
-              }
-            }
-
-            if(completed >= found.length){
-              if(!errors){
-                if (self._stream) {
-                  self._stream = null;
-                } else if (callback) {
-                  callback( null, results );
-                }
-              } else {
-                if (callback) {
-                  callback("Could not get all geometries", null);
-                }
-              }
-            }
-          }
-        };
-
-        var error = function(){
-          completed++;
-          errors++;
-          if(completed >= found.length){
-            if (callback) {
-              callback("Could not get all geometries", null);
-            }
-          }
-        };
-
-        // for each result see if the polygon contains the point
-        if(found && found.length){
-          var getCB = function(err, result){
-            if (err) {
-              error();
-            } else {
-              evaluate( result );
-            }
-          };
-
-          for (var i = 0; i < found.length; i++) {
-            self.get(found[i], getCB);
-          }
-        } else {
-          if (callback) {
-            callback(null, results);
-          }
-        }
-      });
-
-      sync.start();
-
-    }));
+    return this._genericSpatialOperation(geojson, indexQuery, 'within', callback);
   };
 
   GeoStore.prototype.update = function(geojson, callback){

--- a/node/terraformer-geostore.js
+++ b/node/terraformer-geostore.js
@@ -518,6 +518,139 @@ var Stream = require('stream');
 
   };
 
+  GeoStore.prototype.intersects = function(geojson){
+    var args = Array.prototype.slice.call(arguments);
+    args.shift();
+
+    var callback = args.pop();
+    if (args.length) {
+      var indexQuery = args[0];
+    }
+
+
+    // make a new deferred
+    var shape = new Terraformer.Primitive(geojson);
+
+    // create our envelope
+    var envelope = Terraformer.Tools.calculateEnvelope(shape);
+
+    // search the index
+    this.index.search(envelope, bind(this, function(err, found){
+      var results = [];
+      var completed = 0;
+      var errors = 0;
+      var self = this;
+      var sync = new Sync();
+      var set;
+      var i;
+
+      // should we do set elimination with additional indexes?
+      if (indexQuery && self._additional_indexes.length) {
+        // convert "found" to an object with keys
+        set = { };
+
+        for (i = 0; i < found.length; i++) {
+          set[found[i]] = true;
+        }
+
+        // iterate through the queries, find the correct indexes, and apply them
+        var keys = Object.keys(indexQuery);
+
+        for (var j = 0; j < keys.length; j++) {
+          for (i = 0; i < self._additional_indexes.length; i++) {
+            // index property matches query
+            if (self._additional_indexes[i].property === keys[j]) {
+              var which = indexQuery[keys[j]], index = self._additional_indexes[i].index;
+
+              sync.next(function (index, which, set, cb) {
+                var next = this;
+                eliminateForIndex(index, which, set, function (err, newSet) {
+                  set = newSet;
+                  cb(err);
+                });
+              }, index, which, set);
+            }
+          }
+        }
+
+      }
+
+      sync.next(function () {
+        // if we have a set, it is our new "found"
+        if (set) {
+          found = Object.keys(set);
+        }
+
+        // the function to evalute results from the index
+        var evaluate = function(primitive){
+          completed++;
+          if ( primitive ){
+            var geometry = new Terraformer.Primitive(primitive.geometry);
+
+            if (shape.intersects(geometry)){
+              if (self._stream) {
+                if (completed === found.length) {
+                  self._stream.emit("data", primitive);
+                  self._stream.emit("end");
+                } else {
+                  self._stream.emit("data", primitive);
+                }
+              } else {
+                results.push(primitive);
+              }
+            }
+
+            if(completed >= found.length){
+              if(!errors){
+                if (self._stream) {
+                  self._stream = null;
+                } else if (callback) {
+                  callback( null, results );
+                }
+              } else {
+                if (callback) {
+                  callback("Could not get all geometries", null);
+                }
+              }
+            }
+          }
+        };
+
+        var error = function(){
+          completed++;
+          errors++;
+          if(completed >= found.length){
+            if (callback) {
+              callback("Could not get all geometries", null);
+            }
+          }
+        };
+
+        // for each result see if the polygon contains the point
+        if(found && found.length){
+          var getCB = function(err, result){
+            if (err) {
+              error();
+            } else {
+              evaluate( result );
+            }
+          };
+
+          for (var i = 0; i < found.length; i++) {
+            self.get(found[i], getCB);
+          }
+        } else {
+          if (callback) {
+            callback(null, results);
+          }
+        }
+      });
+
+      sync.start();
+
+    }));
+  };
+
   GeoStore.prototype.update = function(geojson, callback){
     var feature = Terraformer.Primitive(geojson);
 

--- a/node/terraformer-geostore.js
+++ b/node/terraformer-geostore.js
@@ -252,15 +252,28 @@ var Stream = require('stream');
     }));
   };
 
-  GeoStore.prototype.contains = function(geojson){
-    var args = Array.prototype.slice.call(arguments);
-    args.shift();
-
-    var callback = args.pop();
-    if (args.length) {
-      var indexQuery = args[0];
+  GeoStore.prototype._genericSpatialOperation = function (geojson, indexQuery, operationName, callback) {
+    var indexSearchMethod, shapeGeometryTest;
+    switch (operationName) {
+      case 'within':
+        indexSearchMethod = this.index.within;
+        shapeGeometryTest = function(geometry, shape) {
+          return geometry.within(shape);
+        };
+        break;
+      case 'contains':
+        indexSearchMethod = this.index.search;
+        shapeGeometryTest = function(geometry, shape) {
+          return shape.within(geometry);
+        };
+        break;
+      case 'intersects':
+        indexSearchMethod = this.index.search;
+        shapeGeometryTest = function(geometry, shape) {
+          return shape.intersects(geometry);
+        };
+        break;
     }
-
 
     // make a new deferred
     var shape = new Terraformer.Primitive(geojson);
@@ -269,7 +282,7 @@ var Stream = require('stream');
     var envelope = Terraformer.Tools.calculateEnvelope(shape);
 
     // search the index
-    this.index.search(envelope, bind(this, function(err, found){
+    indexSearchMethod(envelope, bind(this, function(err, found){
       var results = [];
       var completed = 0;
       var errors = 0;
@@ -306,7 +319,6 @@ var Stream = require('stream');
             }
           }
         }
-
       }
 
       sync.next(function () {
@@ -320,11 +332,14 @@ var Stream = require('stream');
           completed++;
           if ( primitive ){
             var geometry = new Terraformer.Primitive(primitive.geometry);
-
-            if (shape.within(geometry)){
+            if (shapeGeometryTest(geometry, shape)){
               if (self._stream) {
                 if (completed === found.length) {
-                  self._stream.emit("data", primitive);
+                  if (operationName == "within") {
+                    self._stream.emit("done", primitive);
+                  } else {
+                    self._stream.emit("data", primitive);
+                  }
                   self._stream.emit("end");
                 } else {
                   self._stream.emit("data", primitive);
@@ -383,272 +398,44 @@ var Stream = require('stream');
       sync.start();
 
     }));
+  };
+
+  GeoStore.prototype.intersects = function (geojson) {
+    var indexQuery;
+    var args = Array.prototype.slice.call(arguments);
+    args.shift();
+
+    var callback = args.pop();
+    if (args.length) {
+      indexQuery = args[0];
+    }
+
+    return this._genericSpatialOperation(geojson, indexQuery, 'intersects', callback);
+  };
+
+  GeoStore.prototype.contains = function (geojson) {
+    var indexQuery;
+    var args = Array.prototype.slice.call(arguments);
+    args.shift();
+
+    var callback = args.pop();
+    if (args.length) {
+      indexQuery = args[0];
+    }
+
+    return this._genericSpatialOperation(geojson, indexQuery, 'contains', callback);
   };
 
   GeoStore.prototype.within = function(geojson){
+    var indexQuery;
     var args = Array.prototype.slice.call(arguments);
     args.shift();
-
     var callback = args.pop();
     if (args.length) {
-      var indexQuery = args[0];
+      indexQuery = args[0];
     }
 
-    // make a new deferred
-    var shape = new Terraformer.Primitive(geojson);
-
-    // create our envelope
-    var envelope = Terraformer.Tools.calculateEnvelope(shape);
-
-    // search the index using within
-    this.index.within(envelope, bind(this, function(err, found){
-      var results = [];
-      var completed = 0;
-      var errors = 0;
-      var self = this;
-      var sync = new Sync();
-      var set;
-      var i;
-
-      // should we do set elimination with additional indexes?
-      if (indexQuery && self._additional_indexes.length) {
-        // convert "found" to an object with keys
-        set = { };
-
-        for (i = 0; i < found.length; i++) {
-          set[found[i]] = true;
-        }
-
-        // iterate through the queries, find the correct indexes, and apply them
-        var keys = Object.keys(indexQuery);
-
-        for (var j = 0; j < keys.length; j++) {
-          for (i = 0; i < self._additional_indexes.length; i++) {
-            // index property matches query
-            if (self._additional_indexes[i].property === keys[j]) {
-              var which = indexQuery[keys[j]], index = self._additional_indexes[i].index;
-
-              sync.next(function (index, which, set, cb) {
-                var next = this;
-                eliminateForIndex(index, which, set, function (err, newSet) {
-                  set = newSet;
-                  cb(err);
-                });
-              }, index, which, set);
-            }
-          }
-        }
-
-      }
-
-      sync.next(function () {
-        // if we have a set, it is our new "found"
-        if (set) {
-          found = Object.keys(set);
-        }
-
-        // the function to evalute results from the index
-        var evaluate = function(primitive){
-          completed++;
-          if ( primitive ){
-            var geometry = new Terraformer.Primitive(primitive.geometry);
-
-            if (geometry.within(shape)){
-              if (self._stream) {
-                if (completed === found.length) {
-                  self._stream.emit("done", primitive);
-                  self._stream.emit("end");
-                } else {
-                  self._stream.emit("data", primitive);
-                }
-              } else {
-                results.push(primitive);
-              }
-            }
-
-            if(completed >= found.length){
-              if(!errors){
-                if (self._stream) {
-                  self._stream = null;
-                } else if (callback) {
-                  callback( null, results );
-                }
-              } else {
-                if (callback) {
-                  callback("Could not get all geometries", null);
-                }
-              }
-            }
-          }
-        };
-
-        var error = function(){
-          completed++;
-          errors++;
-          if(completed >= found.length){
-            if (callback) {
-              callback("Could not get all geometries", null);
-            }
-          }
-        };
-
-        // for each result see if the polygon contains the point
-        if(found && found.length){
-          var getCB = function(err, result){
-            if (err) {
-              error();
-            } else {
-              evaluate( result );
-            }
-          };
-
-          for (var i = 0; i < found.length; i++) {
-            self.get(found[i], getCB);
-          }
-        } else {
-          if (callback) {
-            callback(null, results);
-          }
-        }
-
-      });
-
-      sync.start();
-    }));
-
-  };
-
-  GeoStore.prototype.intersects = function(geojson){
-    var args = Array.prototype.slice.call(arguments);
-    args.shift();
-
-    var callback = args.pop();
-    if (args.length) {
-      var indexQuery = args[0];
-    }
-
-
-    // make a new deferred
-    var shape = new Terraformer.Primitive(geojson);
-
-    // create our envelope
-    var envelope = Terraformer.Tools.calculateEnvelope(shape);
-
-    // search the index
-    this.index.search(envelope, bind(this, function(err, found){
-      var results = [];
-      var completed = 0;
-      var errors = 0;
-      var self = this;
-      var sync = new Sync();
-      var set;
-      var i;
-
-      // should we do set elimination with additional indexes?
-      if (indexQuery && self._additional_indexes.length) {
-        // convert "found" to an object with keys
-        set = { };
-
-        for (i = 0; i < found.length; i++) {
-          set[found[i]] = true;
-        }
-
-        // iterate through the queries, find the correct indexes, and apply them
-        var keys = Object.keys(indexQuery);
-
-        for (var j = 0; j < keys.length; j++) {
-          for (i = 0; i < self._additional_indexes.length; i++) {
-            // index property matches query
-            if (self._additional_indexes[i].property === keys[j]) {
-              var which = indexQuery[keys[j]], index = self._additional_indexes[i].index;
-
-              sync.next(function (index, which, set, cb) {
-                var next = this;
-                eliminateForIndex(index, which, set, function (err, newSet) {
-                  set = newSet;
-                  cb(err);
-                });
-              }, index, which, set);
-            }
-          }
-        }
-
-      }
-
-      sync.next(function () {
-        // if we have a set, it is our new "found"
-        if (set) {
-          found = Object.keys(set);
-        }
-
-        // the function to evalute results from the index
-        var evaluate = function(primitive){
-          completed++;
-          if ( primitive ){
-            var geometry = new Terraformer.Primitive(primitive.geometry);
-
-            if (shape.intersects(geometry)){
-              if (self._stream) {
-                if (completed === found.length) {
-                  self._stream.emit("data", primitive);
-                  self._stream.emit("end");
-                } else {
-                  self._stream.emit("data", primitive);
-                }
-              } else {
-                results.push(primitive);
-              }
-            }
-
-            if(completed >= found.length){
-              if(!errors){
-                if (self._stream) {
-                  self._stream = null;
-                } else if (callback) {
-                  callback( null, results );
-                }
-              } else {
-                if (callback) {
-                  callback("Could not get all geometries", null);
-                }
-              }
-            }
-          }
-        };
-
-        var error = function(){
-          completed++;
-          errors++;
-          if(completed >= found.length){
-            if (callback) {
-              callback("Could not get all geometries", null);
-            }
-          }
-        };
-
-        // for each result see if the polygon contains the point
-        if(found && found.length){
-          var getCB = function(err, result){
-            if (err) {
-              error();
-            } else {
-              evaluate( result );
-            }
-          };
-
-          for (var i = 0; i < found.length; i++) {
-            self.get(found[i], getCB);
-          }
-        } else {
-          if (callback) {
-            callback(null, results);
-          }
-        }
-      });
-
-      sync.start();
-
-    }));
+    return this._genericSpatialOperation(geojson, indexQuery, 'within', callback);
   };
 
   GeoStore.prototype.update = function(geojson, callback){

--- a/spec/geostoreSpec.js
+++ b/spec/geostoreSpec.js
@@ -506,7 +506,7 @@ describe("geostore", function() {
 
         gs.within({
           "type": "Polygon",
-          "coordinates": [ [ [ -122, 45, 0.0 ], [ -123, 45, 0.0 ], [ -123, 46, 0.0 ], [ -122, 46, 0.0 ], [ -122, 45, 0.0 ] ] ]
+          "coordinates": [ [ [ -121, 45, 0.0 ], [ -123, 45, 0.0 ], [ -123, 46, 0.0 ], [ -121, 46, 0.0 ], [ -121, 45, 0.0 ] ] ]
         },
         {
           "name":
@@ -517,7 +517,7 @@ describe("geostore", function() {
         function (err, res) {
           expect(err).toEqual(null);
           expect(res.length).toEqual(1);
-          expect(res.id).toEqual(1);
+          expect(res[0].id).toEqual(1);
         });
       });
 

--- a/src/geostore.js
+++ b/src/geostore.js
@@ -427,6 +427,139 @@
 
   };
 
+  GeoStore.prototype.intersects = function(geojson){
+    var args = Array.prototype.slice.call(arguments);
+    args.shift();
+
+    var callback = args.pop();
+    if (args.length) {
+      var indexQuery = args[0];
+    }
+
+
+    // make a new deferred
+    var shape = new Terraformer.Primitive(geojson);
+
+    // create our envelope
+    var envelope = Terraformer.Tools.calculateEnvelope(shape);
+
+    // search the index
+    this.index.search(envelope, bind(this, function(err, found){
+      var results = [];
+      var completed = 0;
+      var errors = 0;
+      var self = this;
+      var sync = new Sync();
+      var set;
+      var i;
+
+      // should we do set elimination with additional indexes?
+      if (indexQuery && self._additional_indexes.length) {
+        // convert "found" to an object with keys
+        set = { };
+
+        for (i = 0; i < found.length; i++) {
+          set[found[i]] = true;
+        }
+
+        // iterate through the queries, find the correct indexes, and apply them
+        var keys = Object.keys(indexQuery);
+
+        for (var j = 0; j < keys.length; j++) {
+          for (i = 0; i < self._additional_indexes.length; i++) {
+            // index property matches query
+            if (self._additional_indexes[i].property === keys[j]) {
+              var which = indexQuery[keys[j]], index = self._additional_indexes[i].index;
+
+              sync.next(function (index, which, set, cb) {
+                var next = this;
+                eliminateForIndex(index, which, set, function (err, newSet) {
+                  set = newSet;
+                  cb(err);
+                });
+              }, index, which, set);
+            }
+          }
+        }
+
+      }
+
+      sync.next(function () {
+        // if we have a set, it is our new "found"
+        if (set) {
+          found = Object.keys(set);
+        }
+
+        // the function to evalute results from the index
+        var evaluate = function(primitive){
+          completed++;
+          if ( primitive ){
+            var geometry = new Terraformer.Primitive(primitive.geometry);
+
+            if (shape.intersects(geometry)){
+              if (self._stream) {
+                if (completed === found.length) {
+                  self._stream.emit("data", primitive);
+                  self._stream.emit("end");
+                } else {
+                  self._stream.emit("data", primitive);
+                }
+              } else {
+                results.push(primitive);
+              }
+            }
+
+            if(completed >= found.length){
+              if(!errors){
+                if (self._stream) {
+                  self._stream = null;
+                } else if (callback) {
+                  callback( null, results );
+                }
+              } else {
+                if (callback) {
+                  callback("Could not get all geometries", null);
+                }
+              }
+            }
+          }
+        };
+
+        var error = function(){
+          completed++;
+          errors++;
+          if(completed >= found.length){
+            if (callback) {
+              callback("Could not get all geometries", null);
+            }
+          }
+        };
+
+        // for each result see if the polygon contains the point
+        if(found && found.length){
+          var getCB = function(err, result){
+            if (err) {
+              error();
+            } else {
+              evaluate( result );
+            }
+          };
+
+          for (var i = 0; i < found.length; i++) {
+            self.get(found[i], getCB);
+          }
+        } else {
+          if (callback) {
+            callback(null, results);
+          }
+        }
+      });
+
+      sync.start();
+
+    }));
+  };
+
   GeoStore.prototype.update = function(geojson, callback){
     var feature = Terraformer.Primitive(geojson);
 


### PR DESCRIPTION
Added a new method (`GeoStore.prototype.intersects`) to add searching the geostore for geometry intersection (in addition to `contains` and `within`).